### PR TITLE
[ww] - Autofixes

### DIFF
--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -3,20 +3,22 @@ FROM debian:latest AS runtime
 
 WORKDIR /app
 
-RUN apt update && apt install curl
+RUN ["apt","update","&&","apt","install","--no-install-recommends","-y","curl"]
 
 # No -f curl
 # http url instead of https url
 # /usr/src not cleaned up
-RUN curl http://google.com && mkdir -p /usr/src && touch /usr/src/data
+RUN ["curl","-f","http://google.com","&&","mkdir","-p","/usr/src","&&","touch","/usr/src/data"]
 
 # No cleanup after apt install
 # No -y in apt install
 # No --no-install-recommends in apt
-RUN apt-get update && apt-get install npm
+RUN ["apt-get","update","&&","apt-get","install","--no-install-recommends","-y","npm","&&","rm -rf /etc/apt/sources.list.d/*"]
 
-COPY . .
+COPY --keep-git-dir=false --link=false . .
 
-RUN npm install
+RUN ["npm","install"]
 
-ENTRYPOINT ["node", "index.js"]
+RUN ["groupadd -r nonroot && useradd --no-log-init -r -g nonroot nonroot"]
+USER nonroot
+ENTRYPOINT ["node","index.js"]


### PR DESCRIPTION



# whale watcher autofix PR (7 Fixed, 2 Unfixed)





## ✅ Automatically Fixed Issues


  
 
  - `curl_always_use_f`: Ensure that curl always uses -f flag
  


  
 
  - `apt_get_always_agree`: Ensure that apt get has the -y flag
  


  
 
  - `apt_always_agree`: Ensure that apt has the -y flag
  


  
 
  - `apt_get_skip_recommends`: Ensure that apt get always skips recommends
  


  
 
  - `apt_skip_recommends`: Ensure that apt always skips recommends
  


  
 
  - `apt_sources_empty`: Ensure apt sources are empty
  


  
 
  - `user_not_root`: Final user should not be root
  







## ❌ Detected but Not Automatically Fixable


  
 
  - `use_https_over_http`: Ensure that only https connections are used
  


  
 
  - `clean_npm_cache_after_npm_install`: Use npm cache clean after an npm install
  






> This is an autogenerated PR! (For now) This being open blocks whale watcher from opening further PRs.
